### PR TITLE
Fix array of initial conditions bug in Base

### DIFF
--- a/dysts/base.py
+++ b/dysts/base.py
@@ -317,8 +317,8 @@ class DynSys(BaseDyn):
 
         m = len(np.array(self.ic).shape)
 
-        # check for analytical Jacobian
-        if self.jac(self.ic, 0) is not None:
+        # check for analytical Jacobian, with condition of ic being a ndim array
+        if (self.ic.ndim > 1 and self.jac(self.ic[0],0)) or self.jac(self.ic, 0) is not None:
             jac = lambda t, x : self.jac(x, t)
         else:
             jac = None


### PR DESCRIPTION
when I installed the most recent update via cloning the repo and `pip install .`, I ran into a bug when rerunning part of the demo notebook here:

```
# ## Solve for multiple initial conditions
model = Lorenz()
model.ic = model.ic[None, :] * np.random.random(20)[:, None]
sol = model.make_trajectory(100, resample=True)
plt.figure()
plt.plot(sol[..., 0].T, sol[..., 1].T);
```

Tracing it back I found the bug to be in the line I edited, which threw an error when self.ic is a multidimensional array. I fixed it to check this condition and ensure that a jacobian exists, which only requires looking at the first initial condition int he list .
